### PR TITLE
moved ForceSensorData to Sai2Model class

### DIFF
--- a/src/Sai2Model.cpp
+++ b/src/Sai2Model.cpp
@@ -142,6 +142,12 @@ void Sai2Model::set_dq(const Eigen::VectorXd& dq) {
 	_dq = dq;
 }
 
+bool Sai2Model::isLinkInRobot(const std::string& link_name) const {
+	if (_link_names_to_id_map.find(link_name) == _link_names_to_id_map.end()) {
+		return false;
+	}
+	return true;
+}
 
 void Sai2Model::updateKinematics()
 {
@@ -348,8 +354,6 @@ void Sai2Model::JvLocalFrame(MatrixXd& J,
 
 	J = rot_in_link.transpose() * link_rot.transpose() * J;
 }
-
-
 
 void Sai2Model::Jw(MatrixXd& J,
  const string& link_name)

--- a/src/Sai2Model.h
+++ b/src/Sai2Model.h
@@ -29,15 +29,19 @@ struct ForceSensorData {
 	// transform from link to sensor frame. Measured moments are with respect to
 	// the sensor frame origin
 	Eigen::Affine3d _transform_in_link;
-	Eigen::Vector3d _force;	  // force applied to the environment in sensor frame
-	Eigen::Vector3d _moment;  // moment applied to the environment in sensor frame
+	Eigen::Vector3d _force_local_frame;	  // force applied to the environment in sensor frame
+	Eigen::Vector3d _moment_local_frame;  // moment applied to the environment in sensor frame
+	Eigen::Vector3d _force_world_frame;	  // force applied to the environment in world frame
+	Eigen::Vector3d _moment_world_frame;  // moment applied to the environment in world frame
 
 	ForceSensorData()
 		: _robot_name(""),
 		  _link_name(""),
 		  _transform_in_link(Eigen::Affine3d::Identity()),
-		  _force(Eigen::Vector3d::Zero()),
-		  _moment(Eigen::Vector3d::Zero()) {}
+		  _force_local_frame(Eigen::Vector3d::Zero()),
+		  _moment_local_frame(Eigen::Vector3d::Zero()),
+		  _force_world_frame(Eigen::Vector3d::Zero()),
+		  _moment_world_frame(Eigen::Vector3d::Zero()) {}
 };
 
 struct SphericalJointDescription {
@@ -128,6 +132,8 @@ public:
 
     // getter for joint names
     std::vector<std::string> joint_names() const;
+
+    bool isLinkInRobot(const std::string& link_name) const;
 
     /**
      * @brief      update the kinematics for the current robot configuration.

--- a/src/Sai2Model.h
+++ b/src/Sai2Model.h
@@ -22,6 +22,24 @@ typedef Matrix< bool, 6, 1 > Vector6bool;
 namespace Sai2Model
 {
 
+// Basic data structure for force sensor data
+struct ForceSensorData {
+	std::string _robot_name;  // name of robot to which sensor is attached
+	std::string _link_name;	  // name of link to which sensor is attached
+	// transform from link to sensor frame. Measured moments are with respect to
+	// the sensor frame origin
+	Eigen::Affine3d _transform_in_link;
+	Eigen::Vector3d _force;	  // force applied to the environment in sensor frame
+	Eigen::Vector3d _moment;  // moment applied to the environment in sensor frame
+
+	ForceSensorData()
+		: _robot_name(""),
+		  _link_name(""),
+		  _transform_in_link(Eigen::Affine3d::Identity()),
+		  _force(Eigen::Vector3d::Zero()),
+		  _moment(Eigen::Vector3d::Zero()) {}
+};
+
 struct SphericalJointDescription {
 	string name;
 	int index;


### PR DESCRIPTION
This is done to allow the simulation, graphics and potentially controllers to use the same data class for sensed forces