### PR TITLE
use joint mid point as initial if not specified

### DIFF
--- a/src/parser/UrdfToSai2Model.cpp
+++ b/src/parser/UrdfToSai2Model.cpp
@@ -334,6 +334,12 @@ bool construct_model(
 						*(urdf_joint->calibration->falling);
 				}
 			}
+		} else { // use mid point of joint limits
+			if (urdf_joint->limits) {
+				initial_joint_positions[joint_q_index] =
+					(urdf_joint->limits->upper + urdf_joint->limits->lower) /
+					2.0;
+			}
 		}
 
 		// get the joint limits

--- a/tests/urdf/rpsprbot.urdf
+++ b/tests/urdf/rpsprbot.urdf
@@ -58,6 +58,7 @@
         <origin xyz="0.000000 0.000000 1.000000" rpy="-0.000000 0.000000 -0.000000" />
         <axis xyz="0 0 1" />
         <limit lower="0" upper="2.0" effort="200" velocity="1.0" />
+		<calibration rising="0.0" />
     </joint>
     <joint name="j2" type="spherical">
         <parent link="link1" />
@@ -71,6 +72,7 @@
         <origin xyz="0.000000 0.000000 1.000000" rpy="-0.000000 0.000000 -0.000000" />
         <axis xyz="0 0 1" />
         <limit lower="0" upper="3.0" effort="250" velocity="2.0" />
+		<calibration rising="0.0" />
     </joint>
     <joint name="j4" type="revolute">
         <parent link="link3" />

--- a/tests/urdf/rrpbot.urdf
+++ b/tests/urdf/rrpbot.urdf
@@ -49,6 +49,7 @@
         <origin xyz="0.000000 0.000000 1.000000" rpy="-0.000000 0.000000 -0.000000" />
         <axis xyz="0 0 1" />
         <limit lower="-0.9" upper="2.0" effort="200" velocity="1.0" />
+		<calibration rising="0.0" />
     </joint>
 
 </robot>


### PR DESCRIPTION
if no initial joint position is specified, use the mid point between joint limits