### PR TITLE
update matrix range basis function to compute faster

### DIFF
--- a/src/Sai2Model.cpp
+++ b/src/Sai2Model.cpp
@@ -1221,7 +1221,7 @@ MatrixXd matrixRangeBasis(const MatrixXd& matrix, const double& tolerance) {
 
 	const int max_range = min(matrix.rows(), matrix.cols());
 	int task_dof = max_range;
-	for (int i = 0; i < range_size; ++i) {
+	for (int i = (range_size - max_range); i < range_size; ++i) {
 		if (es.eigenvalues()(i) / lambda_0 < tolerance) {
 			task_dof -= 1;
 		} else {

--- a/src/Sai2Model.cpp
+++ b/src/Sai2Model.cpp
@@ -1212,27 +1212,27 @@ MatrixXd matrixRangeBasis(const MatrixXd& matrix, const double& tolerance) {
 		return MatrixXd::Zero(range_size, 1);
 	}
 
-	JacobiSVD<MatrixXd> svd(matrix, ComputeThinU | ComputeThinV);
+	SelfAdjointEigenSolver<MatrixXd> es(matrix * matrix.transpose());
 
-	double sigma_0 = svd.singularValues()(0);
-	if (sigma_0 < tolerance) {
+	double lambda_0 = es.eigenvalues()(range_size - 1);
+	if (lambda_0 < tolerance) {
 		return MatrixXd::Zero(range_size, 1);
 	}
 
 	const int max_range = min(matrix.rows(), matrix.cols());
 	int task_dof = max_range;
-	for (int i = svd.singularValues().size() - 1; i > 0; i--) {
-		if (svd.singularValues()(i) / sigma_0 < tolerance) {
+	for (int i = 0; i < range_size; ++i) {
+		if (es.eigenvalues()(i) / lambda_0 < tolerance) {
 			task_dof -= 1;
 		} else {
 			break;
 		}
 	}
 
-	if (task_dof == matrix.rows()) {
-		return MatrixXd::Identity(max_range, max_range);
+	if (task_dof == range_size) {
+		return MatrixXd::Identity(range_size, range_size);
 	} else {
-		return svd.matrixU().leftCols(task_dof);
+		return es.eigenvectors().rightCols(task_dof).rowwise().reverse();
 	}
 }
 

--- a/tests/Tests_Sai2Model.cpp
+++ b/tests/Tests_Sai2Model.cpp
@@ -1154,7 +1154,7 @@ TEST_F(Sai2ModelTest, MatrixRange) {
 	MatrixXd J = model_rrbot->Jv("link1");
 	MatrixXd JRange = matrixRangeBasis(J);
 	MatrixXd expected_Range = MatrixXd::Zero(3, 1);
-	expected_Range(1, 0) = -1;
+	expected_Range(1, 0) = 1;
 	EXPECT_TRUE(checkEigenMatricesEqual(expected_Range, JRange));
 }
 


### PR DESCRIPTION
Use the eigen decomposition of M*M^T instead of the svd in order to find the left range space of the matrix as it is faster